### PR TITLE
various fixes for mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Easiest with the package contained in the BlueBrain fork of [Spack](https://gith
 Clone the project:
 
 ```console
-$ gh repo clone BlueBrain/parquet-converters -- --recursive --shallow-submodules
+$ git clone --recursive --shallow-submodules git@github.com:openbraininstitute/parquet-converters.git
 ```
 
 The following dependencies should be provided:

--- a/src/circuit/sonata_file.h
+++ b/src/circuit/sonata_file.h
@@ -92,7 +92,7 @@ public:
 
 
 protected:
-    SonataFile() = default;
+    SonataFile() = delete;
 
     bool parallel_mode_;
     HighFive::File file_;

--- a/src/circuit/sonata_writer.cpp
+++ b/src/circuit/sonata_writer.cpp
@@ -10,10 +10,16 @@
 #include <functional>
 #include <thread>
 #include <iostream>
+#include <sstream>
 #include <unordered_set>
 
 #include <nlohmann/json.hpp>
-#include <range/v3/view.hpp>
+
+// #include <range/v3/view.hpp>
+// #include <iostream>
+// #include <ranges>
+// #include <string_view>
+// #include <vector>
 
 #include "version.h"
 
@@ -53,19 +59,27 @@ SonataWriter::SonataWriter(const string & filepath,
 void throw_invalid_column(const std::string& col_name,
                           const std::unordered_set<std::string>& names,
                           const std::vector<std::string>& notfound) {
-    std::string msg = "wrong nesting for column " + col_name;
-    msg += ": ";
-    if (names.size() > 0) {
-        msg += "unrecognized subcolumn(s) ";
-        msg += ranges::join_with_view(names, ", ") | ranges::to<std::string>();
+    std::ostringstream oss;
+    oss << "wrong nesting for column " << col_name << ": ";
+    if (!names.empty()) {
+        oss << "unrecognized subcolumn(s) ";
+        auto it = names.begin();
+        oss << *it++;
+        while (it != names.end()) {
+            oss << ", " << *it++;
+        }
     }
     if (names.size() > 0 and notfound.size() > 0)
-        msg += " and ";
+        oss << " and ";
     if (notfound.size() > 0) {
-        msg += "missing subcolumn(s) ";
-        msg += ranges::join_with_view(notfound, ", ") | ranges::to<std::string>();
+        oss << "missing subcolumn(s) ";
+        auto it = notfound.begin();
+        oss << *it++;
+        while (it != notfound.end()) {
+            oss << ", " << *it++;
+        }
     }
-    throw std::runtime_error(msg);
+    throw std::runtime_error(oss.str());
 }
 
 

--- a/src/circuit/sonata_writer.cpp
+++ b/src/circuit/sonata_writer.cpp
@@ -15,12 +15,6 @@
 
 #include <nlohmann/json.hpp>
 
-// #include <range/v3/view.hpp>
-// #include <iostream>
-// #include <ranges>
-// #include <string_view>
-// #include <vector>
-
 #include "version.h"
 
 //#define NEURON_LOGGING true

--- a/src/touch2parquet.cpp
+++ b/src/touch2parquet.cpp
@@ -112,7 +112,7 @@ int main( int argc, char* argv[] ) {
                 work_unit = static_cast<size_t>(std::ceil(convert_limit/double(mpi_size)));
             }
             auto offset = work_unit * mpi_rank;
-            work_unit = std::min(tr.record_count() - offset, work_unit);
+            work_unit = std::min(static_cast<size_t>(tr.record_count() - offset), work_unit);
 
             TouchConverter converter(tr, tw);
             if (mpi_rank == 0) {

--- a/src/touches/parquet_writer.cpp
+++ b/src/touches/parquet_writer.cpp
@@ -303,8 +303,9 @@ void TouchWriterParquet::_writeBuffer(uint length) {
     RowGroupWriter* rg_writer = file_writer->AppendRowGroup();
 
     //pre_neuron / post_neuron [ids, section, segment]
+
     int64_writer = static_cast<Int64Writer*>(rg_writer->NextColumn());
-    int64_writer->WriteBatch(length, nullptr, nullptr, static_cast<Int64Writer*>(_buffer->synapse_id));
+    int64_writer->WriteBatch(length, nullptr, nullptr, _buffer->synapse_id);
     int32_writer = static_cast<Int32Writer*>(rg_writer->NextColumn());
     int32_writer->WriteBatch(length, nullptr, nullptr, _buffer->pre_neuron_id);
     int32_writer = static_cast<Int32Writer*>(rg_writer->NextColumn());

--- a/src/touches/parquet_writer.cpp
+++ b/src/touches/parquet_writer.cpp
@@ -304,7 +304,7 @@ void TouchWriterParquet::_writeBuffer(uint length) {
 
     //pre_neuron / post_neuron [ids, section, segment]
     int64_writer = static_cast<Int64Writer*>(rg_writer->NextColumn());
-    int64_writer->WriteBatch(length, nullptr, nullptr, _buffer->synapse_id);
+    int64_writer->WriteBatch(length, nullptr, nullptr, static_cast<Int64Writer*>(_buffer->synapse_id));
     int32_writer = static_cast<Int32Writer*>(rg_writer->NextColumn());
     int32_writer->WriteBatch(length, nullptr, nullptr, _buffer->pre_neuron_id);
     int32_writer = static_cast<Int32Writer*>(rg_writer->NextColumn());

--- a/src/touches/parquet_writer.h
+++ b/src/touches/parquet_writer.h
@@ -8,9 +8,11 @@
 #pragma once
 
 #include <parquet/api/writer.h>
+#include <parquet/types.h>
 #include <arrow/io/file.h>
 #include "../generic_writer.h"
 #include "touch_defs.h"
+
 
 namespace neuron_parquet {
 namespace touches {
@@ -72,7 +74,7 @@ private:
 
     template <int buf_len>
     struct BUF_T{
-        long long synapse_id[buf_len];
+        int64_t synapse_id[buf_len];
         int pre_neuron_id[buf_len];
         int post_neuron_id[buf_len];
         int pre_section[buf_len];

--- a/src/touches/parquet_writer.h
+++ b/src/touches/parquet_writer.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <parquet/api/writer.h>
-#include <parquet/types.h>
 #include <arrow/io/file.h>
 #include "../generic_writer.h"
 #include "touch_defs.h"

--- a/src/touches/parquet_writer.h
+++ b/src/touches/parquet_writer.h
@@ -72,7 +72,7 @@ private:
 
     template <int buf_len>
     struct BUF_T{
-        long synapse_id[buf_len];
+        long long synapse_id[buf_len];
         int pre_neuron_id[buf_len];
         int post_neuron_id[buf_len];
         int pre_section[buf_len];

--- a/src/touches/touch_reader.cpp
+++ b/src/touches/touch_reader.cpp
@@ -6,7 +6,7 @@
  *
  */
 #include <time.h>
-
+#include <sstream>
 #include <range/v3/all.hpp>
 
 #include "touch_reader.h"

--- a/src/touches/touch_reader.cpp
+++ b/src/touches/touch_reader.cpp
@@ -5,6 +5,7 @@
  * @author Fernando Pereira <fernando.pereira@epfl.ch>
  *
  */
+#include <sstream>
 #include <time.h>
 
 #include <range/v3/all.hpp>

--- a/src/touches/touch_reader.cpp
+++ b/src/touches/touch_reader.cpp
@@ -5,7 +5,6 @@
  * @author Fernando Pereira <fernando.pereira@epfl.ch>
  *
  */
-#include <sstream>
 #include <time.h>
 
 #include <range/v3/all.hpp>


### PR DESCRIPTION
- INT64 parquet is a long on ubuntu and a long long on mac. Moved to int64_t
- `join_with_view` just does not stop complaining about forward range even if vector has it. I suspect it does not support something and I do not have cpp 23. Let's go back to the world of streams for now. The error is related to a `forward_range` not defined. I tried also with vectors and so on and it keeps giving the same error. I could not find a way to fix this except reverting to the old ways

```
==> Error: ProcessError: Command exited with status 2:
    'make' '-j14'

42 errors found in build log:
     80     [ 46%] Building CXX object src/CMakeFiles/CircuitParquet.dir/circuit/sonata_file.cpp.o
     81     cd /Users/katta/OBI/test/parquet-converters/spack-build-sd7pa3i/src && /Users/katta/OBI/spack/opt/spack/darwin-macos-m1/apple-clang-16.0.0/openmpi-4.1.6-2unagqdxk4zqxhapl4zfiq2xnoer743g/bin/mpic++ -DH5_BUILT_AS_DYNAMIC_LIB -
            DHIGHFIVE_HAS_CONCEPTS=0 -DJSON_USE_IMPLICIT_CONVERSIONS=1 -DMPI_NO_CPPBIND -I/Users/katta/OBI/test/parquet-converters/src -I/Users/katta/OBI/test/parquet-converters/spack-build-sd7pa3i/src -isystem /Users/katta/OBI/spack/op
            t/spack/darwin-macos-m1/apple-clang-16.0.0/hdf5-1.14.3-nr7ou2jwvb3rhmdzdpv4p6qcn6w7nttc/include -isystem /Users/katta/OBI/spack/opt/spack/darwin-macos-m1/apple-clang-16.0.0/arrow-10.0.1-r5sjy5jrjvvgbnrfbhbtehhijgts65bk/inclu
            de -isystem /Users/katta/OBI/spack/opt/spack/darwin-macos-m1/apple-clang-16.0.0/nlohmann-json-3.9.1-nex75alqetbvjg5mfqgsa5leazmwhuro/include -isystem /Users/katta/OBI/spack/opt/spack/darwin-macos-m1/apple-clang-16.0.0/highfi
            ve-2.10.0-iaqaf7f6c3uul7ysmbwuolpeowslk663/include -isystem /Users/katta/OBI/spack/opt/spack/darwin-macos-m1/apple-clang-16.0.0/range-v3-0.11.0-p7rhau5iscep6ktgwjeltal7b7kmzdqr/include -O3 -DNDEBUG -std=gnu++17 -arch arm64 -
            isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -mmacosx-version-min=15.0 -Werror=unused-result -MD -MT src/CMakeFiles/CircuitParquet.dir/circuit/sonata_writer.cpp.o -MF CMakeFiles/CircuitParquet.dir/circuit/son
            ata_writer.cpp.o.d -o CMakeFiles/CircuitParquet.dir/circuit/sonata_writer.cpp.o -c /Users/katta/OBI/test/parquet-converters/src/circuit/sonata_writer.cpp
     82     cd /Users/katta/OBI/test/parquet-converters/spack-build-sd7pa3i/src && /Users/katta/OBI/spack/opt/spack/darwin-macos-m1/apple-clang-16.0.0/openmpi-4.1.6-2unagqdxk4zqxhapl4zfiq2xnoer743g/bin/mpic++ -DH5_BUILT_AS_DYNAMIC_LIB -
            DHIGHFIVE_HAS_CONCEPTS=0 -DJSON_USE_IMPLICIT_CONVERSIONS=1 -DMPI_NO_CPPBIND -I/Users/katta/OBI/test/parquet-converters/src -I/Users/katta/OBI/test/parquet-converters/spack-build-sd7pa3i/src -isystem /Users/katta/OBI/spack/op
            t/spack/darwin-macos-m1/apple-clang-16.0.0/hdf5-1.14.3-nr7ou2jwvb3rhmdzdpv4p6qcn6w7nttc/include -isystem /Users/katta/OBI/spack/opt/spack/darwin-macos-m1/apple-clang-16.0.0/arrow-10.0.1-r5sjy5jrjvvgbnrfbhbtehhijgts65bk/inclu
            de -isystem /Users/katta/OBI/spack/opt/spack/darwin-macos-m1/apple-clang-16.0.0/nlohmann-json-3.9.1-nex75alqetbvjg5mfqgsa5leazmwhuro/include -isystem /Users/katta/OBI/spack/opt/spack/darwin-macos-m1/apple-clang-16.0.0/highfi
            ve-2.10.0-iaqaf7f6c3uul7ysmbwuolpeowslk663/include -isystem /Users/katta/OBI/spack/opt/spack/darwin-macos-m1/apple-clang-16.0.0/range-v3-0.11.0-p7rhau5iscep6ktgwjeltal7b7kmzdqr/include -O3 -DNDEBUG -std=gnu++17 -arch arm64 -
            isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -mmacosx-version-min=15.0 -Werror=unused-result -MD -MT src/CMakeFiles/CircuitParquet.dir/circuit/sonata_file.cpp.o -MF CMakeFiles/CircuitParquet.dir/circuit/sonat
            a_file.cpp.o.d -o CMakeFiles/CircuitParquet.dir/circuit/sonata_file.cpp.o -c /Users/katta/OBI/test/parquet-converters/src/circuit/sonata_file.cpp
     83     In file included from /Users/katta/OBI/test/parquet-converters/src/circuit/sonata_writer.cpp:16:
     84     In file included from /Users/katta/OBI/spack/opt/spack/darwin-macos-m1/apple-clang-16.0.0/range-v3-0.11.0-p7rhau5iscep6ktgwjeltal7b7kmzdqr/include/range/v3/view.hpp:42:
     85     In file included from /Users/katta/OBI/spack/opt/spack/darwin-macos-m1/apple-clang-16.0.0/range-v3-0.11.0-p7rhau5iscep6ktgwjeltal7b7kmzdqr/include/range/v3/view/for_each.hpp:28:
  >> 86     /Users/katta/OBI/spack/opt/spack/darwin-macos-m1/apple-clang-16.0.0/range-v3-0.11.0-p7rhau5iscep6ktgwjeltal7b7kmzdqr/include/range/v3/view/join.hpp:362:9: error: static assertion failed due to requirement 'static_cast<bool>(
            forward_range<const char *>)': Concept assertion failed : forward_range<ValRng>
     87       362 |         CPP_assert(forward_range<ValRng>);
     88           |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     89     /Users/katta/OBI/spack/opt/spack/darwin-macos-m1/apple-clang-16.0.0/range-v3-0.11.0-p7rhau5iscep6ktgwjeltal7b7kmzdqr/include/concepts/concepts.hpp:184:19: note: expanded from macro 'CPP_assert'
     90       184 |     static_assert(static_cast<bool>(__VA_ARGS__),                               \
     91           |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     92     /Users/katta/OBI/test/parquet-converters/src/circuit/sonata_writer.cpp:60:17: note: in instantiation of template class 'ranges::join_with_view<std::unordered_set<std::string>, const char *>' requested here
     93        60 |          msg += ranges::join_with_view(names, ", ") | ranges::to<std::string>();
     94           |                 ^
     95     In file included from /Users/katta/OBI/test/parquet-converters/src/circuit/sonata_writer.cpp:16:
     96     In file included from /Users/katta/OBI/spack/opt/spack/darwin-macos-m1/apple-clang-16.0.0/range-v3-0.11.0-p7rhau5iscep6ktgwjeltal7b7kmzdqr/include/range/v3/view.hpp:42:
     97     In file included from /Users/katta/OBI/spack/opt/spack/darwin-macos-m1/apple-clang-16.0.0/range-v3-0.11.0-p7rhau5iscep6ktgwjeltal7b7kmzdqr/include/range/v3/view/for_each.hpp:28:
  >> 98     /Users/katta/OBI/spack/opt/spack/darwin-macos-m1/apple-clang-16.0.0/range-v3-0.11.0-p7rhau5iscep6ktgwjeltal7b7kmzdqr/include/range/v3/view/join.hpp:362:9: error: static assertion failed due to requirement 'static_cast<bool>(
            forward_range<const char *>)': Concept assertion failed : forward_range<ValRng>
```

other similar methods do not even appear to exist in `range/v3`. I think we are using something that included in the standard in cpp 23 but we are using the old proposed version. It is hard to find documentation for ranges/v3 as it is shadowed by the std documentation.

Also, `join_with` looks like is missing. Sincerely, this version of ranges is a little faulty and spotty. Do we really want this dependency when it is not needed?


- various smaller problems, I forgot

fix #1

Tested using spack